### PR TITLE
Quick fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,10 +57,10 @@
     "webpack-cli": "^4.6.0"
   },
   "config": {
-    "name": "OpenAPIv3xImporter-beta",
-    "title": "OpenAPI v3.x Importer (beta)",
+    "name": "OpenAPI3Importer",
+    "title": "OpenAPI 3 (beta)",
     "description": "An OpenAPI importer extension for Paw client.",
-    "identifier": "com.luckymarmot.PawExtensions.OpenAPIv3xImporter-beta",
+    "identifier": "com.luckymarmot.PawExtensions.OpenAPI3Importer",
     "fileExtensions": [
       "json",
       "yaml",

--- a/src/lib/converter.ts
+++ b/src/lib/converter.ts
@@ -65,6 +65,10 @@ export default class PawConverter {
    * @returns {Object<OpenAPIV3.Document>}
    */
   public init(): OpenAPIV3.Document<{}> {
+    // import server variables
+    this.importServers()
+
+    // import groups
     this.groupedRequest
       .map(({ path, group }: GroupedRequestType): any =>
         this.createRequestMeta(path, group),
@@ -420,5 +424,27 @@ export default class PawConverter {
     })
 
     return request
+  }
+
+  /**
+   * Imports server variables into environment variables.
+   * Use the default value for the server object.
+   */
+  private importServers() {
+    const document = this.apiParser.api as OpenAPIV3.Document
+    if (document.servers) {
+      document.servers.forEach((serverObject) => {
+        if (serverObject.variables) {
+          Object.entries(serverObject.variables).forEach(([variableName, variableObject]) => {
+            this.getEnviroment()
+              .setEnvironmentVariableValue(
+                variableName,
+                variableObject.default || '',
+                true /* only assign if value is empty */,
+              )
+          })
+        }
+      })
+    }
   }
 }

--- a/src/lib/importer.ts
+++ b/src/lib/importer.ts
@@ -75,7 +75,7 @@ export default class OpenAPIv3Importer implements Paw.Importer {
       (item: Paw.ExtensionItem): Promise<OpenAPIV3.Document> => {
         const apiParser = new SwaggerParser()
         const apiDocument = this.parseContent(item)
-        const filename = item.file.name.replace(/\.(yml|yaml|json)$/, '')
+        const filename = item.file?.name.replace(/\.(yml|yaml|json)$/, '') || item.name
         return apiParser
           .validate(apiDocument, this.parserOptions)
           .then(() => {

--- a/src/utils/environment.ts
+++ b/src/utils/environment.ts
@@ -27,7 +27,7 @@ export default class EnvironmentManager {
   }
 
   public hasEnvironmentVariable(name: string): boolean {
-    return this.getEnvironmentDomain().getVariableByName(name) !== null
+    return !!this.getEnvironmentDomain().getVariableByName(name)
   }
 
   public getEnvironmentVariable(name: string): Paw.EnvironmentVariable {
@@ -50,11 +50,12 @@ export default class EnvironmentManager {
   public setEnvironmentVariableValue(
     variableName: string,
     variableValue: string,
+    onlyIfEmpty?: boolean,
   ) {
     const env = this.getEnvironmentDomain().getEnvironmentByName(this.envName)
-
-    const varMap: MapKeyedWithString<string> = {}
-    varMap[variableName] = variableValue
-    env?.setVariablesValues(varMap)
+    const variable = this.getEnvironmentVariable(variableName)
+    if (env && variable && (!onlyIfEmpty || !variable.getValue(env))) {
+      variable.setValue(variableValue, env)
+    }
   }
 }

--- a/src/utils/paw-url.ts
+++ b/src/utils/paw-url.ts
@@ -16,7 +16,7 @@ export default class PawURL {
   pathname: string
   port: string
   fullUrl: string | DynamicString
-  serverVariables: MapKeyedWithString<OpenAPIV3.ServerVariableObject>
+
   constructor(
     pathItem: OpenAPIV3.PathItemObject,
     openApi: OpenAPIV3.Document,
@@ -41,13 +41,10 @@ export default class PawURL {
       server = openApi.servers[0]
     }
 
-    if (server.variables) {
-      this.serverVariables = server.variables
-    }
-
     this.fullUrl = convertEnvString(
       this.fullUrl as string,
       request,
+      envManager,
     )
 
     if (typeof this.fullUrl === 'string') {


### PR DESCRIPTION
* Suggest a shorter name, simply `OpenAPI3Importer`
* Remove redundant “Importer” in title since Paw adds that at the end

![image](https://user-images.githubusercontent.com/1319906/117019651-e393a080-acf5-11eb-8e49-3f18517dff00.png)

* Fixes a bug when importing from URL

![image](https://user-images.githubusercontent.com/1319906/117019696-ef7f6280-acf5-11eb-8c74-fcd2e0689027.png)

* Fixes importing `servers` variables (as in [this example](https://api.apis.guru/v2/specs/amazonaws.com/amplify/2017-07-25/openapi.yaml))
