### PR TITLE
Fix baseURL

### DIFF
--- a/src/lib/converter.ts
+++ b/src/lib/converter.ts
@@ -470,32 +470,22 @@ export default class PawConverter {
     const document = this.apiParser.api as OpenAPIV3.Document
     if (document.servers) {
       document.servers.forEach((serverObject, index, arr) => {
-        if (serverObject.variables) {
-          Object.entries(serverObject.variables).forEach(
-            ([variableName, variableObject]) => {
-              this.getEnviroment().setEnvironmentVariableValue(
-                variableName,
-                variableObject.default || '',
-                true /* only assign if value is empty */,
-              )
-            },
-          )
-        } else {
-          let envVar
-
-          if (arr.length > 2) {
-            envVar =
-              this.envDomain.getVariableByName('baseURL-' + (index + 1)) ??
-              this.envDomain.createEnvironmentVariable('baseURL-' + (index + 1))
-          } else {
-            envVar =
-              this.envDomain.getVariableByName('baseURL') ??
-              this.envDomain.createEnvironmentVariable('baseURL')
-          }
-
-          envVar.setCurrentValue(validURL(serverObject.url).href)
-          // this.baseURL.push(envVar.id)
+        if (arr.length === 0) {
+          return
         }
+
+        const envVar = this.envDomain.createEnvironmentVariable('baseURL')
+
+        let href = validURL(serverObject.url).href;
+
+        // Remove trailing slash from href if present
+        if (href.endsWith('/')) {
+          href = href.slice(0, -1);
+        }
+
+        envVar.setCurrentValue(href)
+
+        this.baseURL.push(envVar.id)
       })
     }
   }

--- a/src/lib/converter.ts
+++ b/src/lib/converter.ts
@@ -401,6 +401,8 @@ export default class PawConverter {
     securityTypes: OpenAPIV3.SecurityRequirementObject[],
     request: Paw.Request,
   ): Paw.Request {
+    let enVarTokenURL: Paw.EnvironmentVariable | null = null
+
     const document = this.apiParser.api as OpenAPIV3.Document
     // Because there are no references to refer to
     if (!document.components || !document.components.securitySchemes)
@@ -452,10 +454,19 @@ export default class PawConverter {
         )
       }
 
-      if (
+    if (
         (item.type === 'http' && item.scheme === 'bearer') ||
         item.type === 'apiKey'
       ) {
+        if (!enVarTokenURL) {
+          enVarTokenURL =
+            this.envDomain.getVariableByName('token') ||
+            this.envDomain.createEnvironmentVariable('token');
+        }
+        request.addHeader('Authorization', createDynamicString(
+          "Bearer ",
+          createEnvDynamicValue(enVarTokenURL.id),
+        ))
       }
     })
 
@@ -474,7 +485,10 @@ export default class PawConverter {
           return
         }
 
-        const envVar = this.envDomain.createEnvironmentVariable('baseURL')
+        const envVar = (
+          this.envDomain.getVariableByName('baseURL') ||
+          this.envDomain.createEnvironmentVariable('baseURL')
+        )
 
         let href = validURL(serverObject.url).href;
 


### PR DESCRIPTION
It seems this plugin is having a baseURL problem

I see two problems:

- First time a project is imported, baseURL is set to https://echo.paw.cloud
- Deleting all routes and then re-importing then actually sets the proper baseURL.
- Imported baseURL is being added an extra / at the end because the validURL function.

currently using RapidAPI Version 4.4.3 (Retail)